### PR TITLE
chore: limit to one dependency update at the time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,4 @@ updates:
     directory: "/server" # Location of package manifests
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
https://app.dework.xyz/nation3/develop-1?taskId=8a0a10c5-20dd-4a3f-b64b-c9a26c2e25b0

Makes it easier to handle breaking changes.