### PR TITLE
feat: Update Next middleware for newest version

### DIFF
--- a/server/middleware.ts
+++ b/server/middleware.ts
@@ -1,51 +1,51 @@
 import type { NextFetchEvent, NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
-import { config } from './utils/Config'
+import { config as authConfig } from './utils/Config'
 
-export function middleware(req: NextRequest, event: NextFetchEvent) {
+export function middleware(req: NextRequest, _: NextFetchEvent) {
   console.log('middleware')
 
   const pathName = req.nextUrl.pathname
   console.log('pathName:', pathName)
 
-  // Perform Basic Auth on these paths:
-  //   /api/pushNotification
-  //   /api/pushUpdate
-  if (pathName.startsWith('/api/push')) {
-    const authorizationHeader = req.headers.get('authorization')
-    console.log('authorizationHeader:', authorizationHeader)
+  const authorizationHeader = req.headers.get('authorization')
+  console.log('authorizationHeader:', authorizationHeader)
 
-    let wrongCredentials: boolean = false
-    if (authorizationHeader) {
-      // Get header value from "Basic <value>"
-      const headerValueBase64 = authorizationHeader.split(' ')[1]
+  let wrongCredentials: boolean = false
+  if (authorizationHeader) {
+    // Get header value from "Basic <value>"
+    const headerValueBase64 = authorizationHeader.split(' ')[1]
 
-      // Decode from Base64
-      const headerValue = Buffer.from(headerValueBase64, 'base64').toString()
+    // Decode from Base64
+    const headerValue = Buffer.from(headerValueBase64, 'base64').toString()
 
-      // Extract values from "<username>:<password>"
-      const [username, password] = headerValue.split(':')
+    // Extract values from "<username>:<password>"
+    const [username, password] = headerValue.split(':')
 
-      // Get environment variables
-      const basicAuthUsername = String(process.env.BASIC_AUTH_USERNAME)
-      const basicAuthPassword = String(process.env.BASIC_AUTH_PASSWORD)
-      // TODO: enable usage of Config.ts in _middleware.ts
-      // const basicAuthUsername = config.basicAuthUsername
-      // const basicAuthPassword = config.basicAuthPassword
+    // Get environment variables
+    const basicAuthUsername = String(process.env.BASIC_AUTH_USERNAME)
+    const basicAuthPassword = String(process.env.BASIC_AUTH_PASSWORD)
+    // TODO: enable usage of Config.ts in middleware.ts
+    // const basicAuthUsername = authConfig.basicAuthUsername
+    // const basicAuthPassword = authConfig.basicAuthPassword
 
-      // Compare credentials
-      if (username !== basicAuthUsername || password !== basicAuthPassword) {
-        wrongCredentials = true
-      }
+    // Compare credentials
+    if (username !== basicAuthUsername || password !== basicAuthPassword) {
+      wrongCredentials = true
     }
-    console.log('wrongCredentials:', wrongCredentials)
+  }
+  console.log('wrongCredentials:', wrongCredentials)
 
-    if (!authorizationHeader || wrongCredentials) {
-      // Perform Basic Auth
-      req.nextUrl.pathname = `/api/unauthorized`;
-      return NextResponse.rewrite(req.nextUrl);
-    }
+  if (!authorizationHeader || wrongCredentials) {
+    // Perform Basic Auth
+    req.nextUrl.pathname = `/api/unauthorized`;
+    return NextResponse.rewrite(req.nextUrl);
   }
 }
 
-// TODO: Add matcher
+// Perform Basic Auth on these paths:
+  //   /api/pushNotification
+  //   /api/pushUpdate
+export const config = {
+  matcher: '/api/:push*',
+}

--- a/server/middleware.ts
+++ b/server/middleware.ts
@@ -47,5 +47,5 @@ export function middleware(req: NextRequest, _: NextFetchEvent) {
   //   /api/pushNotification
   //   /api/pushUpdate
 export const config = {
-  matcher: '/api/:push*',
+  matcher: ['/api/pushNotification', '/api/pushUpdate'],
 }

--- a/server/middleware.ts
+++ b/server/middleware.ts
@@ -1,5 +1,6 @@
 import type { NextFetchEvent, NextRequest } from 'next/server'
-import { config } from '../../utils/Config'
+import { NextResponse } from 'next/server'
+import { config } from './utils/Config'
 
 export function middleware(req: NextRequest, event: NextFetchEvent) {
   console.log('middleware')
@@ -41,12 +42,10 @@ export function middleware(req: NextRequest, event: NextFetchEvent) {
 
     if (!authorizationHeader || wrongCredentials) {
       // Perform Basic Auth
-      return new Response('401 Unauthorized', {
-        status: 401,
-        headers: {
-          'WWW-Authenticate': 'Basic realm="Secure Area"',
-        },
-      })
+      req.nextUrl.pathname = `/api/unauthorized`;
+      return NextResponse.rewrite(req.nextUrl);
     }
   }
 }
+
+// TODO: Add matcher

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,7 +13,7 @@
         "ethers": "^5.6.9",
         "google-auth-library": "^8.0.2",
         "jsonwebtoken": "^8.5.1",
-        "next": "^12.1.6",
+        "next": "^12.2.5",
         "node-forge": "^1.3.1",
         "react": "^18.1.0",
         "react-dom": "^18.2.0",
@@ -1289,9 +1289,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.6.tgz",
-      "integrity": "sha512-Te/OBDXFSodPU6jlXYPAXpmZr/AkG6DCATAxttQxqOWaq6eDFX25Db3dK0120GZrSZmv4QCe9KsZmJKDbWs4OA=="
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.5.tgz",
+      "integrity": "sha512-vLPLV3cpPGjUPT3PjgRj7e3nio9t6USkuew3JE/jMeon/9Mvp1WyR18v3iwnCuX7eUAm1HmAbJHHLAbcu/EJcw=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "12.2.3",
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.6.tgz",
-      "integrity": "sha512-BxBr3QAAAXWgk/K7EedvzxJr2dE014mghBSA9iOEAv0bMgF+MRq4PoASjuHi15M2zfowpcRG8XQhMFtxftCleQ==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.5.tgz",
+      "integrity": "sha512-cPWClKxGhgn2dLWnspW+7psl3MoLQUcNqJqOHk2BhNcou9ARDtC0IjQkKe5qcn9qg7I7U83Gp1yh2aesZfZJMA==",
       "cpu": [
         "arm"
       ],
@@ -1317,9 +1317,9 @@
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.6.tgz",
-      "integrity": "sha512-EboEk3ROYY7U6WA2RrMt/cXXMokUTXXfnxe2+CU+DOahvbrO8QSWhlBl9I9ZbFzJx28AGB9Yo3oQHCvph/4Lew==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.5.tgz",
+      "integrity": "sha512-vMj0efliXmC5b7p+wfcQCX0AfU8IypjkzT64GiKJD9PgiA3IILNiGJr1fw2lyUDHkjeWx/5HMlMEpLnTsQslwg==",
       "cpu": [
         "arm64"
       ],
@@ -1332,9 +1332,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.6.tgz",
-      "integrity": "sha512-P0EXU12BMSdNj1F7vdkP/VrYDuCNwBExtRPDYawgSUakzi6qP0iKJpya2BuLvNzXx+XPU49GFuDC5X+SvY0mOw==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.5.tgz",
+      "integrity": "sha512-VOPWbO5EFr6snla/WcxUKtvzGVShfs302TEMOtzYyWni6f9zuOetijJvVh9CCTzInnXAZMtHyNhefijA4HMYLg==",
       "cpu": [
         "arm64"
       ],
@@ -1347,9 +1347,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.6.tgz",
-      "integrity": "sha512-9FptMnbgHJK3dRDzfTpexs9S2hGpzOQxSQbe8omz6Pcl7rnEp9x4uSEKY51ho85JCjL4d0tDLBcXEJZKKLzxNg==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.5.tgz",
+      "integrity": "sha512-5o8bTCgAmtYOgauO/Xd27vW52G2/m3i5PX7MUYePquxXAnX73AAtqA3WgPXBRitEB60plSKZgOTkcpqrsh546A==",
       "cpu": [
         "x64"
       ],
@@ -1361,10 +1361,25 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.5.tgz",
+      "integrity": "sha512-yYUbyup1JnznMtEBRkK4LT56N0lfK5qNTzr6/DEyDw5TbFVwnuy2hhLBzwCBkScFVjpFdfiC6SQAX3FrAZzuuw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.6.tgz",
-      "integrity": "sha512-PvfEa1RR55dsik/IDkCKSFkk6ODNGJqPY3ysVUZqmnWMDSuqFtf7BPWHFa/53znpvVB5XaJ5Z1/6aR5CTIqxPw==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.5.tgz",
+      "integrity": "sha512-2ZE2/G921Acks7UopJZVMgKLdm4vN4U0yuzvAMJ6KBavPzqESA2yHJlm85TV/K9gIjKhSk5BVtauIUntFRP8cg==",
       "cpu": [
         "arm"
       ],
@@ -1377,9 +1392,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.6.tgz",
-      "integrity": "sha512-53QOvX1jBbC2ctnmWHyRhMajGq7QZfl974WYlwclXarVV418X7ed7o/EzGY+YVAEKzIVaAB9JFFWGXn8WWo0gQ==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.5.tgz",
+      "integrity": "sha512-/I6+PWVlz2wkTdWqhlSYYJ1pWWgUVva6SgX353oqTh8njNQp1SdFQuWDqk8LnM6ulheVfSsgkDzxrDaAQZnzjQ==",
       "cpu": [
         "arm64"
       ],
@@ -1392,9 +1407,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.6.tgz",
-      "integrity": "sha512-CMWAkYqfGdQCS+uuMA1A2UhOfcUYeoqnTW7msLr2RyYAys15pD960hlDfq7QAi8BCAKk0sQ2rjsl0iqMyziohQ==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.5.tgz",
+      "integrity": "sha512-LPQRelfX6asXyVr59p5sTpx5l+0yh2Vjp/R8Wi4X9pnqcayqT4CUJLiHqCvZuLin3IsFdisJL0rKHMoaZLRfmg==",
       "cpu": [
         "arm64"
       ],
@@ -1407,9 +1422,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.6.tgz",
-      "integrity": "sha512-AC7jE4Fxpn0s3ujngClIDTiEM/CQiB2N2vkcyWWn6734AmGT03Duq6RYtPMymFobDdAtZGFZd5nR95WjPzbZAQ==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.5.tgz",
+      "integrity": "sha512-0szyAo8jMCClkjNK0hknjhmAngUppoRekW6OAezbEYwHXN/VNtsXbfzgYOqjKWxEx3OoAzrT3jLwAF0HdX2MEw==",
       "cpu": [
         "x64"
       ],
@@ -1422,9 +1437,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.6.tgz",
-      "integrity": "sha512-c9Vjmi0EVk0Kou2qbrynskVarnFwfYIi+wKufR9Ad7/IKKuP6aEhOdZiIIdKsYWRtK2IWRF3h3YmdnEa2WLUag==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.5.tgz",
+      "integrity": "sha512-zg/Y6oBar1yVnW6Il1I/08/2ukWtOG6s3acdJdEyIdsCzyQi4RLxbbhkD/EGQyhqBvd3QrC6ZXQEXighQUAZ0g==",
       "cpu": [
         "x64"
       ],
@@ -1437,9 +1452,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.6.tgz",
-      "integrity": "sha512-3UTOL/5XZSKFelM7qN0it35o3Cegm6LsyuERR3/OoqEExyj3aCk7F025b54/707HTMAnjlvQK3DzLhPu/xxO4g==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.5.tgz",
+      "integrity": "sha512-3/90DRNSqeeSRMMEhj4gHHQlLhhKg5SCCoYfE3kBjGpE63EfnblYUqsszGGZ9ekpKL/R4/SGB40iCQr8tR5Jiw==",
       "cpu": [
         "arm64"
       ],
@@ -1452,9 +1467,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.6.tgz",
-      "integrity": "sha512-8ZWoj6nCq6fI1yCzKq6oK0jE6Mxlz4MrEsRyu0TwDztWQWe7rh4XXGLAa2YVPatYcHhMcUL+fQQbqd1MsgaSDA==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.5.tgz",
+      "integrity": "sha512-hGLc0ZRAwnaPL4ulwpp4D2RxmkHQLuI8CFOEEHdzZpS63/hMVzv81g8jzYA0UXbb9pus/iTc3VRbVbAM03SRrw==",
       "cpu": [
         "ia32"
       ],
@@ -1467,9 +1482,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.6.tgz",
-      "integrity": "sha512-4ZEwiRuZEicXhXqmhw3+de8Z4EpOLQj/gp+D9fFWo6ii6W1kBkNNvvEx4A90ugppu+74pT1lIJnOuz3A9oQeJA==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.5.tgz",
+      "integrity": "sha512-7h5/ahY7NeaO2xygqVrSG/Y8Vs4cdjxIjowTZ5W6CKoTKn7tmnuxlUc2h74x06FKmbhAd9agOjr/AOKyxYYm9Q==",
       "cpu": [
         "x64"
       ],
@@ -1525,6 +1540,19 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.3.tgz",
+      "integrity": "sha512-6JrF+fdUK2zbGpJIlN7G3v966PQjyx/dPt1T9km2wj+EUBqgrxCk3uX4Kct16MIm9gGxfKRcfax2hVf5jvlTzA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@swc/helpers/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -5478,14 +5506,16 @@
       }
     },
     "node_modules/next": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.1.6.tgz",
-      "integrity": "sha512-cebwKxL3/DhNKfg9tPZDQmbRKjueqykHHbgaoG4VBRH3AHQJ2HO0dbKFiS1hPhe1/qgc2d/hFeadsbPicmLD+A==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.2.5.tgz",
+      "integrity": "sha512-tBdjqX5XC/oFs/6gxrZhjmiq90YWizUYU6qOWAfat7zJwrwapJ+BYgX2PmiacunXMaRpeVT4vz5MSPSLgNkrpA==",
       "dependencies": {
-        "@next/env": "12.1.6",
+        "@next/env": "12.2.5",
+        "@swc/helpers": "0.4.3",
         "caniuse-lite": "^1.0.30001332",
-        "postcss": "8.4.5",
-        "styled-jsx": "5.0.2"
+        "postcss": "8.4.14",
+        "styled-jsx": "5.0.4",
+        "use-sync-external-store": "1.2.0"
       },
       "bin": {
         "next": "dist/bin/next"
@@ -5494,18 +5524,19 @@
         "node": ">=12.22.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.1.6",
-        "@next/swc-android-arm64": "12.1.6",
-        "@next/swc-darwin-arm64": "12.1.6",
-        "@next/swc-darwin-x64": "12.1.6",
-        "@next/swc-linux-arm-gnueabihf": "12.1.6",
-        "@next/swc-linux-arm64-gnu": "12.1.6",
-        "@next/swc-linux-arm64-musl": "12.1.6",
-        "@next/swc-linux-x64-gnu": "12.1.6",
-        "@next/swc-linux-x64-musl": "12.1.6",
-        "@next/swc-win32-arm64-msvc": "12.1.6",
-        "@next/swc-win32-ia32-msvc": "12.1.6",
-        "@next/swc-win32-x64-msvc": "12.1.6"
+        "@next/swc-android-arm-eabi": "12.2.5",
+        "@next/swc-android-arm64": "12.2.5",
+        "@next/swc-darwin-arm64": "12.2.5",
+        "@next/swc-darwin-x64": "12.2.5",
+        "@next/swc-freebsd-x64": "12.2.5",
+        "@next/swc-linux-arm-gnueabihf": "12.2.5",
+        "@next/swc-linux-arm64-gnu": "12.2.5",
+        "@next/swc-linux-arm64-musl": "12.2.5",
+        "@next/swc-linux-x64-gnu": "12.2.5",
+        "@next/swc-linux-x64-musl": "12.2.5",
+        "@next/swc-win32-arm64-msvc": "12.2.5",
+        "@next/swc-win32-ia32-msvc": "12.2.5",
+        "@next/swc-win32-x64-msvc": "12.2.5"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
@@ -5929,20 +5960,26 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
       "dependencies": {
-        "nanoid": "^3.1.30",
+        "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.1"
+        "source-map-js": "^1.0.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/prelude-ls": {
@@ -6706,9 +6743,9 @@
       }
     },
     "node_modules/styled-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
-      "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.4.tgz",
+      "integrity": "sha512-sDFWLbg4zR+UkNzfk5lPilyIgtpddfxXEULxhujorr5jtePTUqiPDc5BC0v1NRqTr/WaFBGQQUoYToGlF4B2KQ==",
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7104,6 +7141,14 @@
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/utf-8-validate": {
@@ -8691,9 +8736,9 @@
       }
     },
     "@next/env": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.6.tgz",
-      "integrity": "sha512-Te/OBDXFSodPU6jlXYPAXpmZr/AkG6DCATAxttQxqOWaq6eDFX25Db3dK0120GZrSZmv4QCe9KsZmJKDbWs4OA=="
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.5.tgz",
+      "integrity": "sha512-vLPLV3cpPGjUPT3PjgRj7e3nio9t6USkuew3JE/jMeon/9Mvp1WyR18v3iwnCuX7eUAm1HmAbJHHLAbcu/EJcw=="
     },
     "@next/eslint-plugin-next": {
       "version": "12.2.3",
@@ -8704,75 +8749,81 @@
       }
     },
     "@next/swc-android-arm-eabi": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.6.tgz",
-      "integrity": "sha512-BxBr3QAAAXWgk/K7EedvzxJr2dE014mghBSA9iOEAv0bMgF+MRq4PoASjuHi15M2zfowpcRG8XQhMFtxftCleQ==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.5.tgz",
+      "integrity": "sha512-cPWClKxGhgn2dLWnspW+7psl3MoLQUcNqJqOHk2BhNcou9ARDtC0IjQkKe5qcn9qg7I7U83Gp1yh2aesZfZJMA==",
       "optional": true
     },
     "@next/swc-android-arm64": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.6.tgz",
-      "integrity": "sha512-EboEk3ROYY7U6WA2RrMt/cXXMokUTXXfnxe2+CU+DOahvbrO8QSWhlBl9I9ZbFzJx28AGB9Yo3oQHCvph/4Lew==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.5.tgz",
+      "integrity": "sha512-vMj0efliXmC5b7p+wfcQCX0AfU8IypjkzT64GiKJD9PgiA3IILNiGJr1fw2lyUDHkjeWx/5HMlMEpLnTsQslwg==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.6.tgz",
-      "integrity": "sha512-P0EXU12BMSdNj1F7vdkP/VrYDuCNwBExtRPDYawgSUakzi6qP0iKJpya2BuLvNzXx+XPU49GFuDC5X+SvY0mOw==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.5.tgz",
+      "integrity": "sha512-VOPWbO5EFr6snla/WcxUKtvzGVShfs302TEMOtzYyWni6f9zuOetijJvVh9CCTzInnXAZMtHyNhefijA4HMYLg==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.6.tgz",
-      "integrity": "sha512-9FptMnbgHJK3dRDzfTpexs9S2hGpzOQxSQbe8omz6Pcl7rnEp9x4uSEKY51ho85JCjL4d0tDLBcXEJZKKLzxNg==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.5.tgz",
+      "integrity": "sha512-5o8bTCgAmtYOgauO/Xd27vW52G2/m3i5PX7MUYePquxXAnX73AAtqA3WgPXBRitEB60plSKZgOTkcpqrsh546A==",
+      "optional": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.5.tgz",
+      "integrity": "sha512-yYUbyup1JnznMtEBRkK4LT56N0lfK5qNTzr6/DEyDw5TbFVwnuy2hhLBzwCBkScFVjpFdfiC6SQAX3FrAZzuuw==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.6.tgz",
-      "integrity": "sha512-PvfEa1RR55dsik/IDkCKSFkk6ODNGJqPY3ysVUZqmnWMDSuqFtf7BPWHFa/53znpvVB5XaJ5Z1/6aR5CTIqxPw==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.5.tgz",
+      "integrity": "sha512-2ZE2/G921Acks7UopJZVMgKLdm4vN4U0yuzvAMJ6KBavPzqESA2yHJlm85TV/K9gIjKhSk5BVtauIUntFRP8cg==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.6.tgz",
-      "integrity": "sha512-53QOvX1jBbC2ctnmWHyRhMajGq7QZfl974WYlwclXarVV418X7ed7o/EzGY+YVAEKzIVaAB9JFFWGXn8WWo0gQ==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.5.tgz",
+      "integrity": "sha512-/I6+PWVlz2wkTdWqhlSYYJ1pWWgUVva6SgX353oqTh8njNQp1SdFQuWDqk8LnM6ulheVfSsgkDzxrDaAQZnzjQ==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.6.tgz",
-      "integrity": "sha512-CMWAkYqfGdQCS+uuMA1A2UhOfcUYeoqnTW7msLr2RyYAys15pD960hlDfq7QAi8BCAKk0sQ2rjsl0iqMyziohQ==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.5.tgz",
+      "integrity": "sha512-LPQRelfX6asXyVr59p5sTpx5l+0yh2Vjp/R8Wi4X9pnqcayqT4CUJLiHqCvZuLin3IsFdisJL0rKHMoaZLRfmg==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.6.tgz",
-      "integrity": "sha512-AC7jE4Fxpn0s3ujngClIDTiEM/CQiB2N2vkcyWWn6734AmGT03Duq6RYtPMymFobDdAtZGFZd5nR95WjPzbZAQ==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.5.tgz",
+      "integrity": "sha512-0szyAo8jMCClkjNK0hknjhmAngUppoRekW6OAezbEYwHXN/VNtsXbfzgYOqjKWxEx3OoAzrT3jLwAF0HdX2MEw==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.6.tgz",
-      "integrity": "sha512-c9Vjmi0EVk0Kou2qbrynskVarnFwfYIi+wKufR9Ad7/IKKuP6aEhOdZiIIdKsYWRtK2IWRF3h3YmdnEa2WLUag==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.5.tgz",
+      "integrity": "sha512-zg/Y6oBar1yVnW6Il1I/08/2ukWtOG6s3acdJdEyIdsCzyQi4RLxbbhkD/EGQyhqBvd3QrC6ZXQEXighQUAZ0g==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.6.tgz",
-      "integrity": "sha512-3UTOL/5XZSKFelM7qN0it35o3Cegm6LsyuERR3/OoqEExyj3aCk7F025b54/707HTMAnjlvQK3DzLhPu/xxO4g==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.5.tgz",
+      "integrity": "sha512-3/90DRNSqeeSRMMEhj4gHHQlLhhKg5SCCoYfE3kBjGpE63EfnblYUqsszGGZ9ekpKL/R4/SGB40iCQr8tR5Jiw==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.6.tgz",
-      "integrity": "sha512-8ZWoj6nCq6fI1yCzKq6oK0jE6Mxlz4MrEsRyu0TwDztWQWe7rh4XXGLAa2YVPatYcHhMcUL+fQQbqd1MsgaSDA==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.5.tgz",
+      "integrity": "sha512-hGLc0ZRAwnaPL4ulwpp4D2RxmkHQLuI8CFOEEHdzZpS63/hMVzv81g8jzYA0UXbb9pus/iTc3VRbVbAM03SRrw==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.6.tgz",
-      "integrity": "sha512-4ZEwiRuZEicXhXqmhw3+de8Z4EpOLQj/gp+D9fFWo6ii6W1kBkNNvvEx4A90ugppu+74pT1lIJnOuz3A9oQeJA==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.5.tgz",
+      "integrity": "sha512-7h5/ahY7NeaO2xygqVrSG/Y8Vs4cdjxIjowTZ5W6CKoTKn7tmnuxlUc2h74x06FKmbhAd9agOjr/AOKyxYYm9Q==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -8807,6 +8858,21 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+    },
+    "@swc/helpers": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.3.tgz",
+      "integrity": "sha512-6JrF+fdUK2zbGpJIlN7G3v966PQjyx/dPt1T9km2wj+EUBqgrxCk3uX4Kct16MIm9gGxfKRcfax2hVf5jvlTzA==",
+      "requires": {
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -11916,26 +11982,29 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "next": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.1.6.tgz",
-      "integrity": "sha512-cebwKxL3/DhNKfg9tPZDQmbRKjueqykHHbgaoG4VBRH3AHQJ2HO0dbKFiS1hPhe1/qgc2d/hFeadsbPicmLD+A==",
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.2.5.tgz",
+      "integrity": "sha512-tBdjqX5XC/oFs/6gxrZhjmiq90YWizUYU6qOWAfat7zJwrwapJ+BYgX2PmiacunXMaRpeVT4vz5MSPSLgNkrpA==",
       "requires": {
-        "@next/env": "12.1.6",
-        "@next/swc-android-arm-eabi": "12.1.6",
-        "@next/swc-android-arm64": "12.1.6",
-        "@next/swc-darwin-arm64": "12.1.6",
-        "@next/swc-darwin-x64": "12.1.6",
-        "@next/swc-linux-arm-gnueabihf": "12.1.6",
-        "@next/swc-linux-arm64-gnu": "12.1.6",
-        "@next/swc-linux-arm64-musl": "12.1.6",
-        "@next/swc-linux-x64-gnu": "12.1.6",
-        "@next/swc-linux-x64-musl": "12.1.6",
-        "@next/swc-win32-arm64-msvc": "12.1.6",
-        "@next/swc-win32-ia32-msvc": "12.1.6",
-        "@next/swc-win32-x64-msvc": "12.1.6",
+        "@next/env": "12.2.5",
+        "@next/swc-android-arm-eabi": "12.2.5",
+        "@next/swc-android-arm64": "12.2.5",
+        "@next/swc-darwin-arm64": "12.2.5",
+        "@next/swc-darwin-x64": "12.2.5",
+        "@next/swc-freebsd-x64": "12.2.5",
+        "@next/swc-linux-arm-gnueabihf": "12.2.5",
+        "@next/swc-linux-arm64-gnu": "12.2.5",
+        "@next/swc-linux-arm64-musl": "12.2.5",
+        "@next/swc-linux-x64-gnu": "12.2.5",
+        "@next/swc-linux-x64-musl": "12.2.5",
+        "@next/swc-win32-arm64-msvc": "12.2.5",
+        "@next/swc-win32-ia32-msvc": "12.2.5",
+        "@next/swc-win32-x64-msvc": "12.2.5",
+        "@swc/helpers": "0.4.3",
         "caniuse-lite": "^1.0.30001332",
-        "postcss": "8.4.5",
-        "styled-jsx": "5.0.2"
+        "postcss": "8.4.14",
+        "styled-jsx": "5.0.4",
+        "use-sync-external-store": "1.2.0"
       }
     },
     "next-tick": {
@@ -12230,13 +12299,13 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "postcss": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
       "requires": {
-        "nanoid": "^3.1.30",
+        "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.1"
+        "source-map-js": "^1.0.2"
       }
     },
     "prelude-ls": {
@@ -12790,9 +12859,9 @@
       "peer": true
     },
     "styled-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
-      "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.4.tgz",
+      "integrity": "sha512-sDFWLbg4zR+UkNzfk5lPilyIgtpddfxXEULxhujorr5jtePTUqiPDc5BC0v1NRqTr/WaFBGQQUoYToGlF4B2KQ==",
       "requires": {}
     },
     "supports-color": {
@@ -13086,6 +13155,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "utf-8-validate": {
       "version": "5.0.9",

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
     "ethers": "^5.6.9",
     "google-auth-library": "^8.0.2",
     "jsonwebtoken": "^8.5.1",
-    "next": "^12.1.6",
+    "next": "^12.2.5",
     "node-forge": "^1.3.1",
     "react": "^18.1.0",
     "react-dom": "^18.2.0",

--- a/server/pages/api/unauthorized.ts
+++ b/server/pages/api/unauthorized.ts
@@ -1,0 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(
+  _: NextApiRequest,
+  res: NextApiResponse
+) {
+    res.statusCode = 401
+    res.setHeader('WWW-authenticate', 'Basic realm="Secure Area"')
+    res.end(`Authentication Required.`)
+}


### PR DESCRIPTION
## This PR

- Move `_middleware.ts` to the root folder and remove the underscore as mentioned [in the documentation](https://nextjs.org/docs/messages/middleware-upgrade-guide) for Next version `12.2.x` 
- Use matcher to select for which API routes the middleware is executed
- Replace response return with `NextResponse.rewrite` ([documentation](https://nextjs.org/docs/messages/middleware-upgrade-guide#no-response-body))

## Fixes
#62 